### PR TITLE
fixing bower manifest to point to correct spinner js filename

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/harinair/angular-sham-spinner",
     "description": "Angular Sham Spinner - easily integrate Sham spinner in AngularJS Applications",
     "version": "0.0.7",
-    "main": "angular-sham-spinner.js",
+    "main": "angular-sham.spinner.js",
     "dependencies": {
         "sham-spinner": "*",
         "angular": "~1.2"


### PR DESCRIPTION
The file is named `angular-sham.spinner.js` but the bower.json is pointing to `angular-sham-spinner.js` (note the `-spinner` instead of `.spinner`)

This becomes an issue when using build tools like yeoman and grunt that rely on correct bower manifest files.
